### PR TITLE
Adds CGAffineTransform helpers

### DIFF
--- a/SmokeTests/CGAffineTransformSmokeTest.swift
+++ b/SmokeTests/CGAffineTransformSmokeTest.swift
@@ -58,9 +58,7 @@ class CGAffineTransformSmokeTest: XCTestCase {
 		Transform().rotate(xi)
 
 		Transform().invert()
-		Transform().inverse
 
 		Transform().concat(Transform())
-		Transform() * Transform()
 	}
 }

--- a/SmokeTests/CGAffineTransformSmokeTest.swift
+++ b/SmokeTests/CGAffineTransformSmokeTest.swift
@@ -1,0 +1,66 @@
+//
+//  CGAffineTransformSmokeTest.swift
+//  CGAffineTransformSmokeTest
+//
+//  Created by Zak Remer on 7/19/15.
+//  Copyright (c) 2015 Zak. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+class CGAffineTransformSmokeTest: XCTestCase {
+    
+	// This is a smoke test to see if any of this functionality has been included by Apple.
+	// Every line here represents functionality provided by this library.
+	// Any line _not_ throwing a build error has been added by Apple and can be removed.
+
+	typealias Transform = CGAffineTransform
+
+	static let xi = 10
+	static let yi = 11
+	typealias S = CGAffineTransformSmokeTest
+
+	let x = CGFloat(S.xi)
+	let y = CGFloat(S.yi)
+	let xd = Double(S.xi)
+	let yd = Double(S.yi)
+	let xi: Int = S.xi
+	let yi: Int = S.yi
+
+	func testCompilation() {
+		Transform() == Transform()
+
+		Transform.identityTransform
+
+		Transform(scalex: x, y: y)
+		Transform(scalex: xd, y: yd)
+		Transform(scalex: xi, y: yi)
+
+		Transform(translatex: x, y: y)
+		Transform(translatex: xd, y: yd)
+		Transform(translatex: xi, y: yi)
+
+		Transform(rotate: x)
+		Transform(rotate: xd)
+		Transform(rotate: xi)
+
+		Transform().translate(x, ty: y)
+		Transform().translate(xd, ty: yd)
+		Transform().translate(xi, ty: yi)
+
+		Transform().scale(x, sy: y)
+		Transform().scale(xd, sy: yd)
+		Transform().scale(xi, sy: yi)
+
+		Transform().rotate(x)
+		Transform().rotate(xd)
+		Transform().rotate(xi)
+
+		Transform().invert()
+		Transform().inverse
+
+		Transform().concat(Transform())
+		Transform() * Transform()
+	}
+}

--- a/SmokeTests/Info.plist
+++ b/SmokeTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kazmasaurus.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Sosoa.xcodeproj/project.pbxproj
+++ b/Sosoa.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		31EB67121B5F069800C28D8A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0640;
 				ORGANIZATIONNAME = Zak;
 				TargetAttributes = {
@@ -519,6 +520,7 @@
 				31EB67601B5F0A5E00C28D8A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Sosoa.xcodeproj/project.pbxproj
+++ b/Sosoa.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		31EB67211B5F069800C28D8A /* Sosoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 31EB67201B5F069800C28D8A /* Sosoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		31EB67271B5F069800C28D8A /* Sosoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31EB671B1B5F069800C28D8A /* Sosoa.framework */; };
+		31EB67381B5F08C000C28D8A /* CGAffineTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EB67371B5F08C000C28D8A /* CGAffineTransform.swift */; };
+		31EB673A1B5F092300C28D8A /* CGAffineTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EB67391B5F092300C28D8A /* CGAffineTransformTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,6 +29,8 @@
 		31EB67201B5F069800C28D8A /* Sosoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Sosoa.h; sourceTree = "<group>"; };
 		31EB67261B5F069800C28D8A /* SosoaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SosoaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		31EB672C1B5F069800C28D8A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		31EB67371B5F08C000C28D8A /* CGAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransform.swift; sourceTree = "<group>"; };
+		31EB67391B5F092300C28D8A /* CGAffineTransformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransformTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +73,7 @@
 		31EB671D1B5F069800C28D8A /* Sosoa */ = {
 			isa = PBXGroup;
 			children = (
+				31EB67371B5F08C000C28D8A /* CGAffineTransform.swift */,
 				31EB67201B5F069800C28D8A /* Sosoa.h */,
 				31EB671E1B5F069800C28D8A /* Supporting Files */,
 			);
@@ -86,6 +91,7 @@
 		31EB672A1B5F069800C28D8A /* SosoaTests */ = {
 			isa = PBXGroup;
 			children = (
+				31EB67391B5F092300C28D8A /* CGAffineTransformTests.swift */,
 				31EB672B1B5F069800C28D8A /* Supporting Files */,
 			);
 			path = SosoaTests;
@@ -206,6 +212,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				31EB67381B5F08C000C28D8A /* CGAffineTransform.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -213,6 +220,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				31EB673A1B5F092300C28D8A /* CGAffineTransformTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sosoa.xcodeproj/project.pbxproj
+++ b/Sosoa.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		31EB67271B5F069800C28D8A /* Sosoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31EB671B1B5F069800C28D8A /* Sosoa.framework */; };
 		31EB67381B5F08C000C28D8A /* CGAffineTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EB67371B5F08C000C28D8A /* CGAffineTransform.swift */; };
 		31EB673A1B5F092300C28D8A /* CGAffineTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EB67391B5F092300C28D8A /* CGAffineTransformTests.swift */; };
+		31EB67681B5F0AB100C28D8A /* CGAffineTransformSmokeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EB67671B5F0AB100C28D8A /* CGAffineTransformSmokeTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,6 +32,9 @@
 		31EB672C1B5F069800C28D8A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		31EB67371B5F08C000C28D8A /* CGAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransform.swift; sourceTree = "<group>"; };
 		31EB67391B5F092300C28D8A /* CGAffineTransformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransformTests.swift; sourceTree = "<group>"; };
+		31EB67591B5F0A5E00C28D8A /* SmokeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SmokeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		31EB675C1B5F0A5E00C28D8A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		31EB67671B5F0AB100C28D8A /* CGAffineTransformSmokeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransformSmokeTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,6 +53,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		31EB67561B5F0A5E00C28D8A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -57,6 +68,7 @@
 			children = (
 				31EB671D1B5F069800C28D8A /* Sosoa */,
 				31EB672A1B5F069800C28D8A /* SosoaTests */,
+				31EB675A1B5F0A5E00C28D8A /* SmokeTests */,
 				31EB671C1B5F069800C28D8A /* Products */,
 			);
 			sourceTree = "<group>";
@@ -66,6 +78,7 @@
 			children = (
 				31EB671B1B5F069800C28D8A /* Sosoa.framework */,
 				31EB67261B5F069800C28D8A /* SosoaTests.xctest */,
+				31EB67591B5F0A5E00C28D8A /* SmokeTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -101,6 +114,23 @@
 			isa = PBXGroup;
 			children = (
 				31EB672C1B5F069800C28D8A /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		31EB675A1B5F0A5E00C28D8A /* SmokeTests */ = {
+			isa = PBXGroup;
+			children = (
+				31EB67671B5F0AB100C28D8A /* CGAffineTransformSmokeTest.swift */,
+				31EB675B1B5F0A5E00C28D8A /* Supporting Files */,
+			);
+			path = SmokeTests;
+			sourceTree = "<group>";
+		};
+		31EB675B1B5F0A5E00C28D8A /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				31EB675C1B5F0A5E00C28D8A /* Info.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -155,6 +185,23 @@
 			productReference = 31EB67261B5F069800C28D8A /* SosoaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		31EB67581B5F0A5E00C28D8A /* SmokeTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 31EB67611B5F0A5E00C28D8A /* Build configuration list for PBXNativeTarget "SmokeTests" */;
+			buildPhases = (
+				31EB67551B5F0A5E00C28D8A /* Sources */,
+				31EB67561B5F0A5E00C28D8A /* Frameworks */,
+				31EB67571B5F0A5E00C28D8A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SmokeTests;
+			productName = SmokeTests;
+			productReference = 31EB67591B5F0A5E00C28D8A /* SmokeTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -168,6 +215,9 @@
 						CreatedOnToolsVersion = 6.4;
 					};
 					31EB67251B5F069800C28D8A = {
+						CreatedOnToolsVersion = 6.4;
+					};
+					31EB67581B5F0A5E00C28D8A = {
 						CreatedOnToolsVersion = 6.4;
 					};
 				};
@@ -186,6 +236,7 @@
 			targets = (
 				31EB671A1B5F069800C28D8A /* Sosoa */,
 				31EB67251B5F069800C28D8A /* SosoaTests */,
+				31EB67581B5F0A5E00C28D8A /* SmokeTests */,
 			);
 		};
 /* End PBXProject section */
@@ -199,6 +250,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		31EB67241B5F069800C28D8A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		31EB67571B5F0A5E00C28D8A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -221,6 +279,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				31EB673A1B5F092300C28D8A /* CGAffineTransformTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		31EB67551B5F0A5E00C28D8A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				31EB67681B5F0AB100C28D8A /* CGAffineTransformSmokeTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -386,6 +452,36 @@
 			};
 			name = Release;
 		};
+		31EB675F1B5F0A5E00C28D8A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = SmokeTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		31EB67601B5F0A5E00C28D8A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = SmokeTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -415,6 +511,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		31EB67611B5F0A5E00C28D8A /* Build configuration list for PBXNativeTarget "SmokeTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				31EB675F1B5F0A5E00C28D8A /* Debug */,
+				31EB67601B5F0A5E00C28D8A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Sosoa/CGAffineTransform.swift
+++ b/Sosoa/CGAffineTransform.swift
@@ -14,11 +14,6 @@ public func ==(lhs: CGAffineTransform, rhs: CGAffineTransform) -> Bool {
 	return CGAffineTransformEqualToTransform(lhs, rhs)
 }
 
-// MARK: - Concatenation
-public func *(lhs: CGAffineTransform, rhs: CGAffineTransform) -> CGAffineTransform {
-	return lhs.concat(rhs)
-}
-
 extension CGAffineTransform {
 
 	private typealias F = CGFloat // For all the casts
@@ -93,8 +88,6 @@ extension CGAffineTransform {
 	public func invert() -> CGAffineTransform {
 		return CGAffineTransformInvert(self)
 	}
-
-	public var inverse: CGAffineTransform { return invert() }
 
 	// MARK: Concat
 	public func concat(transform: CGAffineTransform) -> CGAffineTransform {

--- a/Sosoa/CGAffineTransform.swift
+++ b/Sosoa/CGAffineTransform.swift
@@ -1,0 +1,110 @@
+//
+//  SwiftTransforms.swift
+//  SwiftTransforms
+//
+//  Created by Zak Remer on 7/17/15.
+//  Copyright (c) 2015 Zak. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Equality
+extension CGAffineTransform: Equatable { }
+public func ==(lhs: CGAffineTransform, rhs: CGAffineTransform) -> Bool {
+	return CGAffineTransformEqualToTransform(lhs, rhs)
+}
+
+// MARK: - Concatenation
+public func *(lhs: CGAffineTransform, rhs: CGAffineTransform) -> CGAffineTransform {
+	return lhs.concat(rhs)
+}
+
+extension CGAffineTransform {
+
+	private typealias F = CGFloat // For all the casts
+
+	// MARK: - Constants
+	public static let identityTransform = CGAffineTransformIdentity
+
+	// MARK: - Properties
+	public var isIdentity: Bool { return CGAffineTransformIsIdentity(self) }
+
+	// MARK: - Inits
+	public init(a: Double, b: Double, c: Double, d: Double, tx: Double, ty: Double) {
+		self.init(a: F(a), b: F(b), c: F(c), d: F(d), tx: F(tx), ty: F(ty))
+	}
+
+	public init(a: Int, b: Int, c: Int, d: Int, tx: Int, ty: Int) {
+		self.init(a: F(a), b: F(b), c: F(c), d: F(d), tx: F(tx), ty: F(ty))
+	}
+
+	// MARK: Scale
+	public init(scalex x: CGFloat, y: CGFloat) { self.init(a: x, b: 0, c: 0, d: y, tx: 0, ty: 0) }
+	public init(scalex x: Double, y: Double) { self.init(scalex: F(x), y: F(y)) }
+	public init(scalex x: Int, y: Int) { self.init(scalex: F(x), y: F(y)) }
+
+	// MARK: Translate
+	public init(translatex x: CGFloat, y: CGFloat) { self.init(a: 1, b: 0, c: 0, d: 1, tx: x, ty: y) }
+	public init(translatex x: Double, y: Double) { self.init(translatex: F(x), y: F(y)) }
+	public init(translatex x: Int, y: Int) { self.init(translatex: F(x), y: F(y)) }
+
+	// MARK: Rotate
+	public init(rotate angle: CGFloat) {
+		self.init(a: cos(angle), b: sin(angle), c: -sin(angle), d: cos(angle), tx: 0, ty: 0)
+	}
+	public init(rotate angle: Double) { self.init(rotate: F(angle)) }
+	public init(rotate angle: Int) { self.init(rotate: F(angle)) }
+
+	// MARK: - Modifications
+	// MARK: Translate
+	public func translate(tx: CGFloat, ty: CGFloat) -> CGAffineTransform {
+		return CGAffineTransformTranslate(self, tx, ty)
+	}
+	public func translate(tx: Double, ty: Double) -> CGAffineTransform {
+		return translate(F(tx), ty: F(ty))
+	}
+	public func translate(tx: Int, ty: Int) -> CGAffineTransform {
+		return translate(F(tx), ty: F(ty))
+	}
+
+	// MARK: Scale
+	public func scale(sx: CGFloat, sy: CGFloat) -> CGAffineTransform {
+		return CGAffineTransformScale(self, sx, sy)
+	}
+	public func scale(sx: Double, sy: Double) -> CGAffineTransform {
+		return CGAffineTransformScale(self, F(sx), F(sy))
+	}
+	public func scale(sx: Int, sy: Int) -> CGAffineTransform {
+		return CGAffineTransformScale(self, F(sx), F(sy))
+	}
+
+	// MARK: Rotate
+	public func rotate(angle: CGFloat) -> CGAffineTransform {
+		return CGAffineTransformRotate(self, angle)
+	}
+	public func rotate(angle: Double) -> CGAffineTransform {
+		return CGAffineTransformRotate(self, F(angle))
+	}
+	public func rotate(angle: Int) -> CGAffineTransform {
+		return CGAffineTransformRotate(self, F(angle))
+	}
+
+	// MARK: Invert
+	public func invert() -> CGAffineTransform {
+		return CGAffineTransformInvert(self)
+	}
+
+	public var inverse: CGAffineTransform { return invert() }
+
+	// MARK: Concat
+	public func concat(transform: CGAffineTransform) -> CGAffineTransform {
+		return CGAffineTransformConcat(self, transform)
+	}
+}
+
+extension CGAffineTransform: Printable {
+	public var description: String { return NSStringFromCGAffineTransform(self) }
+}
+
+
+

--- a/SosoaTests/CGAffineTransformTests.swift
+++ b/SosoaTests/CGAffineTransformTests.swift
@@ -80,11 +80,9 @@ class CGAffineTransformTests: XCTestCase {
 
 	func testInvert() {
 		XCTAssertTrue(transform.invert() == CGAffineTransformInvert(transform))
-		XCTAssertTrue(transform.inverse == transform.invert())
 	}
 
 	func testConcat() {
 		XCTAssertTrue(transform.concat(transform) == CGAffineTransformConcat(transform, transform))
-		XCTAssertTrue(transform * transform == transform.concat(transform))
 	}
 }

--- a/SosoaTests/CGAffineTransformTests.swift
+++ b/SosoaTests/CGAffineTransformTests.swift
@@ -1,0 +1,90 @@
+//
+//  CGAffineTransformTests.swift
+//  CGAffineTransformTests
+//
+//  Created by Zak Remer on 7/17/15.
+//  Copyright (c) 2015 Zak. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Sosoa
+
+class CGAffineTransformTests: XCTestCase {
+    
+	// Testing values
+	static let xi = 10
+	static let yi = 11
+	typealias T = CGAffineTransformTests
+
+	let x = CGFloat(T.xi)
+	let y = CGFloat(T.yi)
+	let xd = Double(T.xi)
+	let yd = Double(T.yi)
+	let xi: Int = T.xi
+	let yi: Int = T.yi
+
+	// MARK: - CGAffineTransform
+	typealias Transform = CGAffineTransform
+
+
+	// MARK: Equality
+	func testEquality() {
+		XCTAssertTrue(Transform() == Transform())
+		XCTAssertFalse(Transform() == CGAffineTransformIdentity)
+		XCTAssertTrue(CGAffineTransformIdentity == CGAffineTransformIdentity)
+		XCTAssertTrue(Transform(translatex: x, y: y) == Transform(a: 1, b: 0, c: 0, d: 1, tx: x, ty: y))
+	}
+
+	// MARK: Identity
+	func testIdentity() {
+		XCTAssertTrue(Transform.identityTransform == CGAffineTransformIdentity)
+		XCTAssertTrue(Transform.identityTransform.isIdentity)
+		XCTAssertTrue(CGAffineTransformIdentity.isIdentity)
+		XCTAssertFalse(Transform(scalex: 10, y: 10).isIdentity)
+	}
+
+	// MARK: Inits
+	func testScaleInit() {
+		XCTAssertTrue(Transform(scalex: x, y: y) == CGAffineTransformMakeScale(x, y))
+		XCTAssertTrue(Transform(scalex: xi, y: yi) == Transform(scalex: xd, y: yd)	)
+	}
+
+	func testTranslateInit() {
+		XCTAssertTrue(Transform(translatex: x, y: y) == CGAffineTransformMakeTranslation(x, y))
+		XCTAssertTrue(Transform(translatex: xi, y: yi) == Transform(translatex: xd, y: yd))
+	}
+
+	func testRotateInit() {
+		XCTAssertTrue(Transform(rotate: x) == CGAffineTransformMakeRotation(x))
+		XCTAssertTrue(Transform(rotate: xi) == Transform(rotate: xd))
+	}
+
+	// MARK: - Modifications
+	let transform = Transform.identityTransform.scale(12.0, sy: 13.0).rotate(1.8)
+
+	func testTranslate() {
+		XCTAssertTrue(transform.translate(x, ty: y) == CGAffineTransformTranslate(transform, x, y))
+		XCTAssertTrue(transform.translate(xd, ty: yd) == transform.translate(xi, ty: yi))
+	}
+
+	func testScale() {
+		XCTAssertTrue(transform.scale(x, sy: y) == CGAffineTransformScale(transform, x, y))
+		XCTAssertTrue(transform.scale(xd, sy: yd) == transform.scale(xi, sy: yi))
+	}
+
+	func testRotate() {
+		XCTAssertTrue(transform.rotate(x) == CGAffineTransformRotate(transform, x))
+		XCTAssertTrue(transform.rotate(xd) == transform.rotate(xi))
+	}
+
+	func testInvert() {
+		XCTAssertTrue(transform.invert() == CGAffineTransformInvert(transform))
+		XCTAssertTrue(transform.inverse == transform.invert())
+	}
+
+	func testConcat() {
+		XCTAssertTrue(transform.concat(transform) == CGAffineTransformConcat(transform, transform))
+		XCTAssertTrue(transform * transform == transform.concat(transform))
+	}
+}


### PR DESCRIPTION
Adds a handful of `CGAffineTransform` helpers.
- `Equatable`
- `init`s to replace global `Make`s: `init(scalex: y:)`, `init(transformx: y:)`, `init(rotate:)`
- `identityTransform` constant.
- `translate`, `rotate`, `scale`, `invert`, and `concat` helpers that wrap the globals.
- ~~`*` as a wrapper for `concat`~~
